### PR TITLE
Display the unsigned tx bytes in hex

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -446,6 +446,8 @@ program
       const unsignedTx = await
         avm.buildBaseTx(prepared.utxoset, amount, [toAddress], fromAddresses, [changeAddress], AVAX_ASSET_ID_SERIALIZED)
         .catch(log_error_and_exit);
+      console.error("Unsigned TX:");
+      console.error(unsignedTx.toBuffer().toString("hex"));
       const signed = await sign_UnsignedTx(unsignedTx, prepared.utxoid_to_path, ledger);
       console.error("Issuing TX...");
       const txid = await avm.issueTx(signed);


### PR DESCRIPTION
This is important, so that at least in theory, somebody can use another
tool to verify what the transaction would actually do